### PR TITLE
[HEDS-621] Array agg parsing order

### DIFF
--- a/Language/SQL/SimpleSQL/Parse.lhs
+++ b/Language/SQL/SimpleSQL/Parse.lhs
@@ -965,7 +965,7 @@ together.
 >         nr <- respectNulls
 >         _ <- closeParen
 >         pure ((flip3 App) nr args)
->     , do
+>     , try $ do
 >        commaSep1 scalarExpr
 >        <**> choice
 >           [closeParen *> choice

--- a/Language/SQL/SimpleSQL/Parse.lhs
+++ b/Language/SQL/SimpleSQL/Parse.lhs
@@ -200,7 +200,7 @@ fixing them in the syntax but leaving them till the semantic checking
 > import Data.Semigroup ((<>))
 > import qualified Data.Text as T
 > import qualified Data.Text.Read as T
-> import Text.Megaparsec (State(..), mkPos, PosState(..), SourcePos(..), defaultTabWidth, runParserT', Token(..)
+> import Text.Megaparsec (State(..), reachOffset, mkPos, PosState(..), SourcePos(..), defaultTabWidth, runParserT', Token(..)
 >                        ,option,between,sepBy,sepBy1,ParsecT, ParseError(..), ErrorItem(..)
 >                        ,try,many,some,(<|>),choice,eof,MonadParsec(..)
 >                        ,option,optional,ParseErrorBundle(..),ErrorFancy(..)
@@ -953,14 +953,14 @@ together.
 > app =
 >     openParen *> choice
 >     [do
->      dis <- duplicates
->      args <- commaSep1 scalarExpr
->      orderBy' <- option [] orderBy
->      lim <- optional (guardDialect diAggregateLimit *> fetch)
->      respNull <- respectNulls
->      _ <- closeParen
->      fil <- optional afilter
->      pure (\name' -> AggregateApp name' dis args orderBy' lim respNull fil)
+>        dis <- duplicates
+>        args <- commaSep1 scalarExpr
+>        respNull <- respectNulls
+>        orderBy' <- option [] orderBy
+>        lim <- optional (guardDialect diAggregateLimit *> fetch)
+>        _ <- closeParen
+>        fil <- optional afilter
+>        pure (\name' -> AggregateApp name' dis args respNull orderBy' lim fil)
 >      -- separate cases with no all or distinct which must have at
 >      -- least one scalar expr
 >     -- handle window query with IGNORE/RESPECT NULLS
@@ -988,8 +988,8 @@ together.
 >     ,([] <$ closeParen) <**> option ((flip3 App) Nothing) (window Nothing <|> withinGroup)
 >     ]
 >   where
->     aggAppWithoutDupeOrd n es f = AggregateApp n SQDefault es [] Nothing Nothing f
->     aggAppWithoutDupe name' args ord lim = AggregateApp name' SQDefault args ord lim Nothing
+>     aggAppWithoutDupeOrd n es f = AggregateApp n SQDefault es Nothing [] Nothing f
+>     aggAppWithoutDupe name' args ord lim = AggregateApp name' SQDefault args Nothing ord lim
 
 > afilter :: Parser ScalarExpr
 > afilter = keyword_ "filter" *> parens (keyword_ "where" *> scalarExpr)

--- a/Language/SQL/SimpleSQL/Parse.lhs
+++ b/Language/SQL/SimpleSQL/Parse.lhs
@@ -953,7 +953,7 @@ together.
 > app =
 >     openParen *> choice
 >     [do
->        dis <- duplicates
+>        dis <- option SQDefault duplicates
 >        args <- commaSep1 scalarExpr
 >        respNull <- respectNulls
 >        orderBy' <- option [] orderBy

--- a/Language/SQL/SimpleSQL/Pretty.lhs
+++ b/Language/SQL/SimpleSQL/Pretty.lhs
@@ -70,16 +70,16 @@ Try to do this when this code is ported to a modern pretty printing lib.
 
 > scalarExpr d (App f es nr) = names f <> parens (commaSep (map (scalarExpr d) es) <> nullsRespect nr)
 
-> scalarExpr dia (AggregateApp f d es od lim nr fil) =
+> scalarExpr dia (AggregateApp f d es nr od lim fil) =
 >     names f
 >     <> parens ((case d of
 >                   Distinct -> text "distinct"
 >                   All -> text "all"
 >                   SQDefault -> empty)
 >                <+> commaSep (map (scalarExpr dia) es)
+>                <+> nullsRespect nr
 >                <+> orderBy dia od
->                <+> me (fetchFirst dia) lim
->                <+> nullsRespect nr)
+>                <+> me (fetchFirst dia) lim)
 >     <+> me (\x -> text "filter"
 >                   <+> parens (text "where" <+> scalarExpr dia x)) fil
 

--- a/Language/SQL/SimpleSQL/Syntax.lhs
+++ b/Language/SQL/SimpleSQL/Syntax.lhs
@@ -151,9 +151,9 @@
 >       {aggName :: [Name] -- ^ aggregate function name
 >       ,aggDistinct :: SetQuantifier -- ^ distinct
 >       ,aggArgs :: [ScalarExpr]-- ^ args
+>       ,aggNullsRespect_ns :: Maybe NullsRespect -- ^ non-standard IGNORE/RESPECT NULLS> 
 >       ,aggOrderBy :: [SortSpec] -- ^ order by
 >       ,aggFetchFirst :: Maybe ScalarExpr -- ^ fetch/limit
->       ,aggNullsRespect_ns :: Maybe NullsRespect -- ^ non-standard IGNORE/RESPECT NULLS> 
 >       ,aggFilter :: Maybe ScalarExpr -- ^ filter
 >       }
 >       -- | aggregates with within group


### PR DESCRIPTION
Changed order of parsers to enable correct parsing of IGNORE/RESPECT NULLS in ARRAY_AGG()